### PR TITLE
feat(US162): design delete api for et news

### DIFF
--- a/src/controllers/etNews.controller.ts
+++ b/src/controllers/etNews.controller.ts
@@ -1,0 +1,29 @@
+import { Request, Response } from 'express';
+
+import deletePostService from '../services/etNews.service';
+
+const deletePostbyID = async (req: Request, res: Response) => {
+    try {
+        const { postid } = req.params;
+
+        const post = await deletePostService.deletePostbyID(postid);
+
+        if (!post) {
+            res.status(404).json({ message: "Post not found" });
+            return;
+        }
+
+        res.status(200).json({
+            message: `The post with ID: ${postid} has been deleted successfully`,
+        });
+        return;
+    } catch (err) {
+        res.status(500).json({
+            message: 'An internal server error occurred',
+            error: err instanceof Error ? err.message : "Unknown error",
+        });
+        return;
+    }
+}   
+
+export default deletePostbyID;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,14 @@
 import express from 'express';
 
+import deleteETNewsRoute from './routes/etNews.route';
 import healthRoute from './routes/health.route';
 
 const app = express();
 const PORT = process.env.PORT || 8080;
 
-
+app.use(express.json());
 app.use('/health', healthRoute);
-
+app.use('/et-news', deleteETNewsRoute);
 app.listen(PORT, () => {
     console.log(`Server is running on http://localhost:${PORT}`);
 });

--- a/src/middlewares/etNewsValidator.mdw.ts
+++ b/src/middlewares/etNewsValidator.mdw.ts
@@ -1,0 +1,19 @@
+import { Request, Response, NextFunction } from 'express';
+
+const validatePostID = (req: Request, res: Response, next: NextFunction) => {
+    const { postid } = req.params;
+
+    if (!postid) {
+        res.status(400).json({ message: "Post ID is required." });
+        return;
+    }
+
+    const regex = /^EN\d{3}$/;
+    if (!regex.test(postid)) {
+        res.status(400).json({ message: "Post ID must follow the format ENXXX, where X is a digit."});
+    }
+
+    next();
+};
+
+export default validatePostID;

--- a/src/routes/etNews.route.ts
+++ b/src/routes/etNews.route.ts
@@ -1,0 +1,9 @@
+import express from 'express';
+
+import deletePostbyID from '../controllers/etNews.controller';
+import validatePostID from '../middlewares/etNewsValidator.mdw';
+const router = express.Router();
+
+router.delete('/:postid?', validatePostID, deletePostbyID);
+
+export default router;

--- a/src/services/etNews.service.ts
+++ b/src/services/etNews.service.ts
@@ -1,0 +1,13 @@
+import db from '../utils/db.util';
+
+class deletePostService {
+    async deletePostbyID(postid: string): Promise<number> {
+        try {
+            const result = await db('posts').where('postid', postid).del();
+            return result;
+        } catch (err) {
+            throw new Error(`Error deleting post: ${err}.`);
+        }
+    }
+}
+export default new deletePostService();


### PR DESCRIPTION
# [US162]: [Develop a Delete API for removing specific ET News post within the Back Office System]

## Description
### Briefly describe the purpose of this pull request.
- Create a Delete API for removing specific ET News post within the Back Office system.

### Jira Task: [US162](https://techetclub.atlassian.net/browse/US-162)

## Changes
### Outline the main changes made in this pull request.
- HTTP method: `delete`
- API endpoint: `/et-news/{id}` for deleting ET activities.
- Implemented validation for the ID to ensure correctness.

## Testing

- [x] Local
![Screenshot 2025-02-15 233110](https://github.com/user-attachments/assets/d2675280-ae9e-432e-b32d-613322dd3bf0)
