### PR TITLE
feat(US159): design post api for et news

### DIFF
--- a/src/controllers/etNews.controller.ts
+++ b/src/controllers/etNews.controller.ts
@@ -1,0 +1,30 @@
+import { Request, Response, NextFunction } from 'express';
+import ETNewsService from '../services/etNews.service';
+
+const etNewsService = new ETNewsService();
+
+export const createETNews = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    try {
+        const { title, category, shortdescription, content, thumbnailimageurl, createddate, updateddate, source, visible, viewcount } = req.body;
+
+        const newPost = await etNewsService.addETNews({
+            title,
+            category,
+            shortdescription,
+            content,
+            thumbnailimageurl,
+            createddate,
+            updateddate,
+            source,
+            visible,
+            viewcount: viewcount || 0,
+        });
+
+        res.status(200).json({
+            message: 'ET News post created successfully',
+            data: newPost,
+        });
+    } catch (error) {
+        next(error); // Chuyển lỗi tới middleware xử lý lỗi
+    }
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-
+import etNewsRoutes from './routes/etNews.route';
 import healthRoute from './routes/health.route';
 
 const app = express();
@@ -7,6 +7,8 @@ const PORT = process.env.PORT || 8080;
 
 
 app.use('/health', healthRoute);
+app.use(express.json());
+app.use(etNewsRoutes);
 
 app.listen(PORT, () => {
     console.log(`Server is running on http://localhost:${PORT}`);

--- a/src/middlewares/etNewsValidator.ts
+++ b/src/middlewares/etNewsValidator.ts
@@ -1,0 +1,63 @@
+import Joi from 'joi';
+import { Request, Response, NextFunction } from 'express';
+
+// Định nghĩa schema Joi
+const etNewsSchema = Joi.object({
+    title: Joi.string().max(50).required().messages({
+        'string.empty': 'Title is required.',
+        'string.max': 'Title must not exceed 50 characters.',
+    }),
+    category: Joi.string()
+        .valid(
+            'Tin chính phủ số',
+            'Tin công nghệ thế giới',
+            'Tin công nghệ Việt Nam',
+            'Tin tạo sự ảnh hưởng'
+        )
+        .required()
+        .messages({
+            'any.only': 'Category must be one of Tin chính phủ số, Tin công nghệ thế giới, Tin công nghệ Việt Nam, Tin tạo sự ảnh hưởng.',
+            'string.empty': 'Category is required.',
+        }),
+    shortdescription: Joi.string().max(100).required().messages({
+        'string.empty': 'ShortDescription is required.',
+        'string.max': 'ShortDescription must not exceed 100 characters.',
+    }),
+    content: Joi.string().required().messages({
+        'string.empty': 'Content is required.',
+    }),
+    source: Joi.string().uri().required().messages({
+        'string.empty': 'Source is required.',
+        'string.uri': 'Source must be a valid URL.',
+    }),
+    visible: Joi.string().required().messages({
+        'any.required': 'Visible is required and must be a string.',
+    }),
+    thumbnailimageurl: Joi.string().uri().optional().messages({
+        'string.uri': 'ThumbnailImageURL must be a valid URL.',
+    }),
+    viewcount: Joi.number().integer().min(0).optional().messages({
+        'number.min': 'ViewCount must be greater than or equal to 0.',
+    }),
+    createddate: Joi.date().iso().required().messages({
+        'date.format': 'CreatedDate must be in ISO 8601 format.',
+    }),
+    updateddate: Joi.date().iso().optional().messages({
+        'date.format': 'UpdatedDate must be in ISO 8601 format.',
+    }),
+});
+
+// Middleware validate dữ liệu
+export const validateETNews = (req: Request, res: Response, next: NextFunction): void => {
+    const { error } = etNewsSchema.validate(req.body, { abortEarly: false });
+    if (error) {
+        // Gửi lỗi và kết thúc
+        res.status(400).json({
+            status: 400,
+            message: 'Validation Error',
+            errors: error.details.map((detail) => detail.message),
+        });
+        return; // Đảm bảo kết thúc middleware
+    }
+    next(); // Chuyển tiếp xử lý nếu không có lỗi
+};

--- a/src/routes/etNews.route.ts
+++ b/src/routes/etNews.route.ts
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+import { createETNews } from '../controllers/etNews.controller';
+import { validateETNews } from '../middlewares/etNewsValidator';
+
+const router = Router();
+
+
+router.post('/v1/et-news', validateETNews, createETNews);
+
+export default router;

--- a/src/services/etNews.service.ts
+++ b/src/services/etNews.service.ts
@@ -1,0 +1,31 @@
+import db from '../utils/db.util';
+
+interface ETNews {
+    postid?: number;
+    title: string;
+    category: string;
+    shortdescription: string;
+    content: string;
+    thumbnailimageurl?: string;
+    createddate: Date,
+    updateddate: Date,
+    source: string;
+    visible: string;
+    viewcount?: number;
+}
+
+
+class ETNewsService {
+    async addETNews(news: ETNews): Promise<ETNews> {
+        try {
+            const [newPost] = await db<ETNews>('posts')
+                .insert(news)
+                .returning('*');
+            return newPost;
+        } catch (error) {
+            throw new Error('Error creating ET News: ' + error.message);
+        }
+    }
+}
+
+export default ETNewsService;


### PR DESCRIPTION
# [US159]: [Develop Create API for Adding New ET News Post in Back Office System]

## Description
### Briefly describe the purpose of this pull request.
- Developing a Create API for adding new ET News posts within the Back Office system.
- This API will allow users to input data for new ET News posts, ensuring validation and proper integration with the database.
### Jira Task: [US159](https://techetclub.atlassian.net/browse/US-159)
## Changes
### Outline the main changes made in this pull request.

- HTTP method: `post`
- API endpoint: `/et-news/` for creating new ET News posts.
- Implemented validation for input fields to ensure correctness


## Testing

- [x] Local: Successfully tested the API using Postman

![Screenshot 2025-02-15 235428](https://github.com/user-attachments/assets/dd7167af-5204-4c68-a327-ff23048c3618)
