### PR TITLE
Feature/us161 create upadate api for et news

### DIFF
--- a/src/controllers/etNews.controller.ts
+++ b/src/controllers/etNews.controller.ts
@@ -1,0 +1,46 @@
+import { Request, Response } from 'express';
+import ETNewsService from '../services/etNews.service';
+
+const etNewsService = new ETNewsService();
+
+export const updateETNewsById = async (req: Request, res: Response): Promise<void> => {
+    const { id } = req.params;
+    const updateData = req.body;
+
+    try {
+        // Validate ID
+        if (!id) {
+            res.status(400).json({
+                status: 400,
+                message: 'Invalid or missing "id" parameter.',
+            });
+            return;
+        }
+
+        // Kiểm tra xem bài viết có tồn tại không
+        const existingPost = await etNewsService.getETNewsById(id);
+        if (!existingPost) {
+            res.status(404).json({
+                status: 404,
+                message: 'ET News post not found.',
+            });
+            return;
+        }
+
+        // Cập nhật bài viết
+        const updatedPost = await etNewsService.updateETNewsById(id, updateData);
+
+        res.status(200).json({
+            status: 200,
+            message: 'ET News post updated successfully.',
+            data: updatedPost,
+        });
+    } catch (error) {
+        console.error('Error updating ET News post:', error);
+        res.status(500).json({
+            status: 500,
+            message: 'Internal Server Error',
+            error: error instanceof Error ? error.message : 'Unknown error',
+        });
+    }
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,13 @@
 import express from 'express';
-
+import etNewsRoutes from './routes/etNews.route';
 import healthRoute from './routes/health.route';
 
 const app = express();
 const PORT = process.env.PORT || 8080;
 
+app.use(express.json());
 
+app.use('/v1/et-news', etNewsRoutes);
 app.use('/health', healthRoute);
 
 app.listen(PORT, () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ const PORT = process.env.PORT || 8080;
 
 app.use(express.json());
 
-app.use('/v1/et-news', etNewsRoutes);
+app.use('/et-news', etNewsRoutes);
 app.use('/health', healthRoute);
 
 app.listen(PORT, () => {

--- a/src/middlewares/etNewsValidator.ts
+++ b/src/middlewares/etNewsValidator.ts
@@ -1,0 +1,58 @@
+import Joi from 'joi';
+import { Request, Response, NextFunction } from 'express';
+
+// Định nghĩa schema Joi
+const updateETNewsSchema = Joi.object({
+    title: Joi.string().max(50).optional().messages({
+        'string.max': 'Title must not exceed 50 characters.',
+    }),
+    category: Joi.string()
+        .valid(
+            'Tin chính phủ số',
+            'Tin công nghệ thế giới',
+            'Tin công nghệ Việt Nam',
+            'Tin tạo sự ảnh hưởng'
+        )
+        .optional()
+        .messages({
+            'any.only': 'Category must be one of Tin chính phủ số, Tin công nghệ thế giới, Tin công nghệ Việt Nam, Tin tạo sự ảnh hưởng.',
+        }),
+    shortdescription: Joi.string().max(100).optional().messages({
+        'string.max': 'ShortDescription must not exceed 100 characters.',
+    }),
+    content: Joi.string().optional().messages({
+        'string.base': 'Content must be a string.',
+    }),
+    source: Joi.string().uri().optional().messages({
+        'string.uri': 'Source must be a valid URI.',
+    }),
+    visible: Joi.string().valid('Yes', 'No').optional().messages({
+        'any.only': 'Visible must be either "Yes" or "No".',
+    }),
+
+});
+
+// Middleware validate dữ liệu
+export const validateUpdateETNews = (req: Request, res: Response, next: NextFunction): void => {
+    // Kiểm tra nếu payload rỗng
+    if (!req.body || Object.keys(req.body).length === 0) {
+        res.status(400).json({
+            status: 400,
+            message: 'Payload is empty. Please provide fields to update.',
+        });
+        return;
+    }
+
+    // Validate payload
+    const { error } = updateETNewsSchema.validate(req.body, { abortEarly: false });
+    if (error) {
+        res.status(400).json({
+            status: 400,
+            message: 'Validation Error',
+            errors: error.details.map((detail) => detail.message),
+        });
+        return;
+    }
+
+    next();
+};

--- a/src/routes/etNews.route.ts
+++ b/src/routes/etNews.route.ts
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+import { updateETNewsById } from '../controllers/etNews.controller';
+import { validateUpdateETNews } from '../middlewares/etNewsValidator';
+
+const router = Router();
+
+
+router.put('/:id', validateUpdateETNews, updateETNewsById);
+
+export default router;

--- a/src/services/etNews.service.ts
+++ b/src/services/etNews.service.ts
@@ -1,0 +1,60 @@
+import db from '../utils/db.util';
+
+interface ETNews {
+    postid?: string;
+    title: string;
+    category: string;
+    shortdescription: string;
+    content: string;
+    thumbnailimageurl?: string;
+    createddate: Date,
+    updateddate: Date,
+    source: string;
+    visible: string;
+    viewcount?: number;
+}
+
+class ETNewsService {
+    // Lấy bài viết theo ID
+    async getETNewsById(id: string): Promise<ETNews | null> {
+        try {
+            const [news] = await db<ETNews>('posts')
+                .where({ postid: id })
+                .select('*');
+            return news || null;
+        } catch (error) {
+            throw new Error('Error retrieving ET News post by ID: ' + error.message);
+        }
+    }
+
+    // Cập nhật bài viết
+    async updateETNewsById(postid: string, updatedFields: Partial<ETNews>): Promise<ETNews | null> {
+        try {
+            // Kiểm tra xem bài viết có tồn tại hay không
+            const [existingPost] = await db('posts').where({ postid }).select('*');
+
+            if (!existingPost) {
+                throw new Error(`ET News post with ID ${postid} does not exist`);
+            }
+
+            // Xử lý các trường được cập nhật
+            if (!updatedFields || typeof updatedFields !== 'object') {
+                throw new Error('Invalid update fields provided');
+            }
+
+            // Cập nhật bài viết
+            const [updatedPost] = await db('posts')
+                .where({ postid })
+                .update(updatedFields)
+                .returning('*');
+
+            return updatedPost;
+        } catch (error) {
+            console.error('Error updating ET News post:', error.message);
+            throw new Error(`Error updating ET News post: ${error.message}`);
+        }
+    }
+
+}
+
+export default ETNewsService;


### PR DESCRIPTION
# [US161]: [Develop Update API for Managing ET News Posts in Back Office System]

## Description
### Briefly describe the purpose of this pull request.
-This API allows users to update details of existing ET News posts, ensuring that modifications are correctly applied to the database.
-Ensures data validation, integrity, and proper logging of changes.
### Jira Task: [US161](https://techetclub.atlassian.net/browse/US-161)

## Changes
### Outline the main changes made in this pull request.
- HTTP method: `put`
- API endpoint: `/et-news/{id}` for updating an existing ET News post.

## Testing
- [x] Local: Successfully tested the API using Postman 
![image](https://github.com/user-attachments/assets/2d3c8f32-4af9-4aad-8a95-42de8a78c56a)

