### PR TITLE
Feature/Build API For Getting Unregistered Personnels

### DIFF
--- a/src/controllers/personnel.controller.ts
+++ b/src/controllers/personnel.controller.ts
@@ -38,7 +38,7 @@ export default {
                 return;
             }
 
-            res.status(201).json();
+            res.status(204).json();
             return;
         } catch (error) {
             console.error("Error deleting multiple personnels:", error);
@@ -61,7 +61,7 @@ export default {
                 return;
             }
 
-            res.status(201).json();
+            res.status(204).json();
             return;
         } catch (error) {
             console.error("Error deleting personnel:", error);

--- a/src/routes/personnel.route.ts
+++ b/src/routes/personnel.route.ts
@@ -9,8 +9,8 @@ router.delete("/bulk-delete", personnelController.deleteMultiplePersonnels);
 router.delete("/:id", personnelController.deletePersonnel);
 router.put("/:id", validate(updatePersonnelSchema), personnelController.updatePersonnel);
 router.get("/", personnelController.getPersonnels);
-router.get("/:id", personnelController.getPersonnelByID);
 router.get("/unregistered", personnelController.getUnregisteredPersonnels);
+router.get("/:id", personnelController.getPersonnelByID);
 router.post("/", validate(createPersonnelWithStatusSchema), personnelController.createPersonnelWithStatus);
 
 export default router; 

--- a/src/services/personnel.service.ts
+++ b/src/services/personnel.service.ts
@@ -8,24 +8,8 @@ export default {
             .leftJoin('account', 'personnel.personnel_id', 'account.personnel_id')
             .whereNull('account.personnel_id')
             .select(
-                'personnel.personnel_id',
-                'personnel.student_id',
-                'personnel.personnel_name',
-                'personnel.email',
-                'personnel.dob',
-                'personnel.gender',
-                'personnel.address',
-                'personnel.faculty',
-                'personnel.university',
-                'personnel.major',
-                'personnel.class',
-                'personnel.cv_type',
-                'personnel.cv_link',
-                'personnel.cohort_name',
-                'personnel_status.term_id',
-                'personnel_status.department_name',
-                'personnel_status.position_name',
-                'personnel_status.personnel_status'
+                'personnel.*',
+                'personnel_status.*'
             );
         return personnels;
     },
@@ -37,24 +21,8 @@ export default {
         const personnels = await db('personnel')
             .join('personnel_status', 'personnel.personnel_id', 'personnel_status.personnel_id')
             .select(
-                'personnel.personnel_id',
-                'personnel.student_id',
-                'personnel.personnel_name',
-                'personnel.email',
-                'personnel.dob',
-                'personnel.gender',
-                'personnel.address',
-                'personnel.faculty',
-                'personnel.university',
-                'personnel.major',
-                'personnel.class',
-                'personnel.cv_type',
-                'personnel.cv_link',
-                'personnel.cohort_name',
-                'personnel_status.term_id',
-                'personnel_status.department_name',
-                'personnel_status.position_name',
-                'personnel_status.personnel_status'
+                'personnel.*',
+                'personnel_status.*'
             )
             .where('personnel_status.department_name', departmentName);
 
@@ -171,24 +139,8 @@ export default {
         const personnel = await db('personnel')
             .join('personnel_status', 'personnel.personnel_id', 'personnel_status.personnel_id')
             .select(
-                'personnel.personnel_id',
-                'personnel.student_id',
-                'personnel.personnel_name',
-                'personnel.email',
-                'personnel.dob',
-                'personnel.gender',
-                'personnel.address',
-                'personnel.faculty',
-                'personnel.university',
-                'personnel.major',
-                'personnel.class',
-                'personnel.cv_type',
-                'personnel.cv_link',
-                'personnel.cohort_name',
-                'personnel_status.term_id',
-                'personnel_status.department_name',
-                'personnel_status.position_name',
-                'personnel_status.personnel_status'
+                'personnel.*',
+                'personnel_status.*'
             )
             .where('personnel.personnel_id', id)
             .first();
@@ -234,24 +186,8 @@ export default {
         const personnels = await db('personnel')
             .join('personnel_status', 'personnel.personnel_id', 'personnel_status.personnel_id')
             .select(
-                'personnel.personnel_id',
-                'personnel.student_id',
-                'personnel.personnel_name',
-                'personnel.email',
-                'personnel.dob',
-                'personnel.gender',
-                'personnel.address',
-                'personnel.faculty',
-                'personnel.university',
-                'personnel.major',
-                'personnel.class',
-                'personnel.cv_type',
-                'personnel.cv_link',
-                'personnel.cohort_name',
-                'personnel_status.term_id',
-                'personnel_status.department_name',
-                'personnel_status.position_name',
-                'personnel_status.personnel_status'
+                'personnel.*',
+                'personnel_status.*'
             );
 
         if (personnels.length === 0) {
@@ -268,24 +204,8 @@ export default {
         const personnels = await db('personnel')
             .join('personnel_status', 'personnel.personnel_id', 'personnel_status.personnel_id')
             .select(
-                'personnel.personnel_id',
-                'personnel.student_id',
-                'personnel.personnel_name',
-                'personnel.email',
-                'personnel.dob',
-                'personnel.gender',
-                'personnel.address',
-                'personnel.faculty',
-                'personnel.university',
-                'personnel.major',
-                'personnel.class',
-                'personnel.cv_type',
-                'personnel.cv_link',
-                'personnel.cohort_name',
-                'personnel_status.term_id',
-                'personnel_status.department_name',
-                'personnel_status.position_name',
-                'personnel_status.personnel_status'
+                'personnel.*',
+                'personnel_status.*'
             )
             .where('personnel_status.personnel_status', status);
 


### PR DESCRIPTION
# Feature: Build API For Getting Unregistered Personnels

## Description
This PR adds a new API endpoint to retrieve personnels who have not yet registered an account in the system. It is designed to help identify users who still need to create an account.

## Changes
- Added `getUnregisteredPersonnels` method in the `personnel.model.ts` to:
  - Join `personnel` and `personnel_status`
  - Left join `account` to filter personnel without an account
- Created a new route `GET /api/personnels/unregistered` to fetch the data
- The route will return personnel details for users without an associated account

## Testing
- [x] Local

[
![Screenshot 2025-04-14 191659](https://github.com/user-attachments/assets/f5238448-daa4-4f1c-9a67-16c3a246c606)

