### PR TITLE
Feature/ Build API For Get Personnels By Status And Department

### DIFF
--- a/src/controllers/personnel.controller.ts
+++ b/src/controllers/personnel.controller.ts
@@ -158,7 +158,21 @@ export default {
         try {
             let personnels;
 
-            if (status && typeof status === "string") {
+            if (
+                status && typeof status === "string" &&
+                departmentName && typeof departmentName === "string"
+            ) {
+                personnels = await personnelService.getPersonnelByDepartmentAndStatus(departmentName, status);
+    
+                if (!personnels || personnels.length === 0) {
+                    res.status(404).json({
+                        message: "No personnel found with the given department and status",
+                        data: [],
+                    });
+                    return;
+                }
+            }
+            else if (status && typeof status === "string") {
                 personnels = await personnelService.getPersonnelByStatus(status);
 
                 if (!personnels || personnels.length === 0) {

--- a/src/services/personnel.service.ts
+++ b/src/services/personnel.service.ts
@@ -211,4 +211,25 @@ export default {
 
         return personnels;
     },
+    getPersonnelByDepartmentAndStatus: async (
+        departmentName: string,
+        status: string
+    ): Promise<any[]> => {
+        if (!departmentName || !status) {
+            throw new Error("Invalid Data: departmentName and status are required");
+        }
+    
+        const personnels = await db('personnel')
+            .join('personnel_status', 'personnel.personnel_id', 'personnel_status.personnel_id')
+            .select(
+                'personnel.*',
+                'personnel_status.*'
+            )
+            .where({
+                'personnel_status.department_name': departmentName,
+                'personnel_status.personnel_status': status
+            });
+    
+        return personnels;
+    }
 };


### PR DESCRIPTION
# [Build API For Get Personnels By Status And Department]

## Description
### Briefly describe the purpose of this pull request.
This pull request implements a new feature that allows fetching personnel records filtered by both `status` and `departmentName` through query parameters in the `GET /personnels` endpoint.

## Changes
### Outline the main changes made in this pull request.
- Added new service method `getPersonnelByDepartmentAndStatus` in `personnel.service.ts`.
- Updated `getPersonnels` controller to support:
  - Filtering by both `status` and `departmentName`
  - Preserving existing functionality for filtering by just one or none
- Ensured proper response handling for no result cases.

## Testing
- [x] Local
![Screenshot 2025-04-15 001106](https://github.com/user-attachments/assets/65dcfb0e-1b49-4884-af66-12cd396b8971)
