### PR TITLE
Feature/swagger content 2

### DIFF
--- a/etweb-swagger.yaml
+++ b/etweb-swagger.yaml
@@ -60,45 +60,45 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/LoginRequest'
+              $ref: "#/components/schemas/LoginRequest"
             example:
               username: "user@example.com"
               password: "12345678"
       responses:
-        '200':
+        "200":
           description: Successful login
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SuccessResponse'
+                $ref: "#/components/schemas/SuccessResponse"
               example:
                 message: "Login successful"
                 accessToken: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
                 refreshToken: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
-        '400':
+        "400":
           description: Invalid username or password
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        '401':
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
           description: Unauthorized
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        '404':
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
           description: User not found
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        '500':
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
           description: Internal Server Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: "#/components/schemas/ErrorResponse"
   /auth/refresh-token:
     post:
       tags:
@@ -107,37 +107,241 @@ paths:
       summary: Refresh JWT token
       description: Refresh the JWT token using the refresh token
       security:
-      - bearerAuth: []
+        - bearerAuth: []
       responses:
-        '200':
+        "200":
           description: Token refreshed successfully
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SuccessResponse'
+                $ref: "#/components/schemas/SuccessResponse"
               example:
                 status: 200
                 message: "Token refreshed successfully"
                 data:
                   accessToken: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
-        '401':
+        "401":
           description: Refresh token is missing
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: "#/components/schemas/ErrorResponse"
                 example:
                   message: "Refresh token is missing."
-        '403':
+        "403":
           description: Forbidden
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: "#/components/schemas/ErrorResponse"
                 example:
                   message: "Invalid token type. Refresh token required."
+  /banners:
+    get:
+      tags:
+        - banners
+      operationId: getAllBanners
+      summary: Get all banners
+      description: Retrieve a list of all banners
+      responses:
+        "200":
+          description: Successful retrieval of banners
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/banners"
+              example:
+                - banner_name: "Welcome Banner"
+                  image_url: "https://example.com/banner.jpg"
+                  visible: true
+        "404":
+          description: No banners found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    post:
+      tags:
+        - banners
+      operationId: createBanner
+      summary: Create a new banner
+      description: Create a new banner with the provided details
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/banners"
+            example:
+              banner_name: "New Banner"
+              image_url: "https://example.com/new-banner.jpg"
+              visible: true
+      responses:
+        "201":
+          description: Banner created successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreatedResponse"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /banners/{id}:
+    get:
+      tags:
+        - banners
+      operationId: getBannerById
+      summary: Get banner by ID
+      description: Retrieve a specific banner by its ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The ID of the banner to retrieve
+      responses:
+        "200":
+          description: Successful retrieval of banner
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/banners"
+              example:
+                banner_name: "Welcome Banner"
+                image_url: "https://example.com/banner.jpg"
+                visible: true
+        "404":
+          description: Banner not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    put:
+      tags:
+        - banners
+      operationId: updateBanner
+      summary: Update an existing banner
+      description: Update the details of an existing banner
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The ID of the banner to update
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/banners"
+            example:
+              banner_name: "Updated Banner"
+              image_url: "https://example.com/updated-banner.jpg"
+              visible: true
+      responses:
+        "200":
+          description: Banner updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessResponse"
+        "404":
+          description: Banner not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    delete:
+      tags:
+        - banners
+      operationId: deleteBanner
+      summary: Delete a banner
+      description: Delete a specific banner by its ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The ID of the banner to delete
+      responses:
+        "204":
+          description: Banner deleted successfully
+        "404":
+          description: Banner not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /banners/bulk-delete:
+    delete:
+      tags:
+        - banners
+      operationId: bulkDeleteBanners
+      summary: Bulk delete banners
+      description: Delete multiple banners at once
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                type: string
+              example: ["banner1", "banner2"]
+      responses:
+        "204":
+          description: Banners deleted successfully
+        "400":
+          description: Invalid request body
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
 components:
   schemas:
+    banners:
+      type: object
+      properties:
+        banner_name:
+          type: string
+          example: "Welcom Banner"
+        image_url:
+          type: string
+          format: uri
+          example: "https://example.com/banner.jpg"
+        visible:
+          type: boolean
+          example: "Indicates whether the banner is visible"
+
     LoginRequest:
       type: object
       properties:
@@ -180,8 +384,7 @@ components:
           type: string
           example: The 'username' field must be a valid username address
   securitySchemes:
-    bearerAuth: 
+    bearerAuth:
       type: http
       scheme: bearer
       bearerFormat: JWT
-    

--- a/etweb-swagger.yaml
+++ b/etweb-swagger.yaml
@@ -185,6 +185,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/CreatedResponse"
+        "401":
+          description: Unauthorized access
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         "500":
           description: Internal server error
           content:
@@ -253,6 +259,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SuccessResponse"
+        "401":
+          description: Unauthorized access
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         "404":
           description: Banner not found
           content:
@@ -281,6 +293,12 @@ paths:
       responses:
         "204":
           description: Banner deleted successfully
+        "401":
+          description: Unauthorized access
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         "404":
           description: Banner not found
           content:
@@ -315,6 +333,12 @@ paths:
           description: Banners deleted successfully
         "400":
           description: Invalid request body
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: Unauthorized access
           content:
             application/json:
               schema:
@@ -372,6 +396,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/CreatedResponse"
+        "401":
+          description: Unauthorized access
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         "500":
           description: Internal server error
           content:
@@ -445,6 +475,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: Unauthorized access
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         "404":
           description: FAQ not found
           content:
@@ -474,6 +510,12 @@ paths:
       responses:
         "204":
           description: FAQ deleted successfully
+        "401":
+          description: Unauthorized access
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         "404":
           description: FAQ not found
           content:
@@ -511,6 +553,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: Unauthorized access
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         "404":
           description: Some FAQs not found
           content:
@@ -541,6 +589,12 @@ paths:
                   terms_text:
                     type: string
                     example: "These are the terms and conditions..."
+        "401":
+          description: Unauthorized access
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         "404":
           description: Terms not found
           content:

--- a/etweb-swagger.yaml
+++ b/etweb-swagger.yaml
@@ -325,6 +325,273 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+  /faqs:
+    get:
+      tags:
+        - faqs
+      operationId: getAllFAQs
+      summary: Get all FAQs
+      description: Retrieve a list of all frequently asked questions
+      responses:
+        "200":
+          description: FAQs retrieved successfully
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/faqs"
+        "404":
+          description: No FAQs found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    post:
+      tags:
+        - faqs
+      operationId: createFAQ
+      summary: Create a new FAQ
+      description: Add a new frequently asked question
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/faqs"
+      responses:
+        "201":
+          description: FAQ created successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreatedResponse"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /faqs/{faq_id}:
+    get:
+      tags:
+        - faqs
+      operationId: getFAQById
+      summary: Get FAQ by ID
+      description: Retrieve a specific FAQ by its ID
+      parameters:
+        - name: faq_id
+          in: path
+          required: true
+          schema:
+            type: string
+            pattern: ^FAQS\d{3}$
+          description: The ID of the FAQ to retrieve
+      responses:
+        "200":
+          description: FAQ retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/faqs"
+        "404":
+          description: FAQ not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    put:
+      tags:
+        - faqs
+      operationId: updateFAQ
+      summary: Update an existing FAQ
+      description: Modify the details of an existing frequently asked question
+      parameters:
+        - name: faq_id
+          in: path
+          required: true
+          schema:
+            type: string
+            pattern: ^FAQS\d{3}$
+          description: The ID of the FAQ to update
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/faqs"
+      responses:
+        "200":
+          description: FAQ updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessResponse"
+        "400":
+          description: Invalid request body
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: FAQ not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    delete:
+      tags:
+        - faqs
+      operationId: deleteFAQ
+      summary: Delete an existing FAQ
+      description: Remove a frequently asked question by its ID
+      parameters:
+        - name: faq_id
+          in: path
+          required: true
+          schema:
+            type: string
+            pattern: ^FAQS\d{3}$
+          description: The ID of the FAQ to delete
+      responses:
+        "204":
+          description: FAQ deleted successfully
+        "404":
+          description: FAQ not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /faqs/bulk-delete:
+    delete:
+      tags:
+        - faqs
+      operationId: bulkDeleteFAQs
+      summary: Bulk delete FAQs
+      description: Delete multiple FAQs at once
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                type: string
+              example: ["FAQS001", "FAQS002"]
+      responses:
+        "204":
+          description: FAQs deleted successfully
+        "400":
+          description: Invalid request body
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Some FAQs not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /terms:
+    get:
+      tags:
+        - terms
+      operationId: getTerms
+      summary: Get terms and conditions
+      description: Retrieve the terms and conditions of the application
+      responses:
+        "200":
+          description: Terms retrieved successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  terms_text:
+                    type: string
+                    example: "These are the terms and conditions..."
+        "404":
+          description: Terms not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /search:
+    get:
+      tags:
+        - search
+      operationId: searchAcrossTables
+      summary: Search across multiple tables
+      description: Search for content in activities, ET news, and ET blog based on keyword
+      parameters:
+        - name: keyword
+          in: query
+          required: true
+          schema:
+            type: string
+          description: Keyword to search for in titles
+      responses:
+        "200":
+          description: Search completed successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SearchResponse"
+        "400":
+          description: Keyword is required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: No results found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 
 components:
   schemas:
@@ -333,6 +600,7 @@ components:
       properties:
         banner_name:
           type: string
+          maxLength: 30
           example: "Welcom Banner"
         image_url:
           type: string
@@ -340,7 +608,93 @@ components:
           example: "https://example.com/banner.jpg"
         visible:
           type: boolean
+          default: false
           example: "Indicates whether the banner is visible"
+      required:
+        - banner_name
+        - image_url
+        - visible
+    faqs:
+      type: object
+      properties:
+        faq_id:
+          type: string
+          pattern: ^FAQS\d{3}$
+          description: Unique identifier for the FAQ
+        faq_category:
+          type: string
+          enum:
+            - Về ET Club
+            - Về hoạt động và sự kiện
+            - Về quy trình tham gia
+            - Khác
+          description: Category of the FAQ
+        question:
+          type: string
+          maxLength: 255
+          description: The frequently asked question
+        answer:
+          type: string
+          minLength: 1
+          description: The answer to the question
+        visible:
+          type: boolean
+          default: true
+          description: Indicates whether the FAQ is visible on the homepage
+        created_on:
+          type: string
+          format: date-time
+          description: Timestamp of FAQ creation
+        last_modified_on:
+          type: string
+          format: date-time
+          description: Timestamp of last modification
+      required:
+        - faq_category
+        - question
+        - answer
+        - visible
+
+    SearchResult:
+      type: object
+      properties:
+        table:
+          type: string
+          enum: [activity, et_news, et_blog]
+          description: Source table of the result
+        activity_id:
+          type: string
+          description: ID if result is from activity table
+        etnews_id:
+          type: string
+          description: ID if result is from et_news table
+        blog_id:
+          type: string
+          description: ID if result is from et_blog table
+        title:
+          type: string
+          description: Title of the content
+        meta_description:
+          type: string
+          description: Meta description of the content
+        thumbnail_image_url:
+          type: string
+          format: uri
+          description: URL of the thumbnail image
+      required:
+        - table
+        - title
+
+    SearchResponse:
+      type: object
+      properties:
+        message:
+          type: string
+          example: "Successfully"
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/SearchResult"
 
     LoginRequest:
       type: object


### PR DESCRIPTION
#  Swagger for Banners, FAQs, Terms, and Search Functionality

## Description
### Briefly describe the purpose of this pull request.
- Add Swagger documentation for API endpoints related to:
  - Banners
  - FAQs 
  - Terms 
  - Search functionality

### Mention any relevant context or background.
- This update helps developers and QA teams better understand and test these endpoints.
- Contributes to comprehensive API documentation for the project.



## Changes
### Outline the main changes made in this pull request.
- Defined Swagger schemas and routes for:
  - `GET /banners` - Get all banners
  - `POST /banners` - Create a new banner
  - `GET /banners/{id}` - Get banner by ID
  - `PUT /banners/{id}` - Update an existing banner
  - `DELETE /banners/{id}` - Delete a banner
  - `DELETE /banners/bulk-delete` - Bulk delete banners
  - `GET /faqs` - Get all FAQs
  - `POST /faqs` - Create a new FAQ
  - `GET /faqs/{faq_id}` - Get FAQ by ID
  - `PUT /faqs/{faq_id}` - Update an existing FAQ
  - `DELETE /faqs/{faq_id}` - Delete an existing FAQ
  - `DELETE /faqs/bulk-delete` - Bulk delete FAQs
  - `GET /terms` - Get terms and conditions
  - `GET /search` - Search across multiple tables
- Verified the documentation renders correctly in Swagger UI.
