### PR TITLE
feat: add filter by category to faqs api

### DIFF
--- a/src/controllers/faq.controller.ts
+++ b/src/controllers/faq.controller.ts
@@ -6,9 +6,29 @@ import faqService from "../services/faq.service";
 export default {
     getAllFAQs: (async (req: Request, res: Response): Promise<void> => {
         try {
-            const groupedFAQs = await faqService.getAllFAQs();
+            const faq_category = req.query.faq_category?.toString();
+            const validCategories = [
+                "Về ET Club",
+                "Về hoạt động và sự kiện",
+                "Về quy trình tham gia",
+                "Khác"
+            ];
 
-            const allEmpty = Object.values(groupedFAQs).every((group) => group.length === 0);
+            if (faq_category && !validCategories.includes(faq_category)) {
+                res.status(400).json({
+                    message: `faq_category must be one of: ${validCategories.join(", ")}`
+                });
+                return;
+            }
+
+            const groupedFAQs = faq_category
+                ? await faqService.getFAQsByCategory(faq_category)
+                : await faqService.getAllFAQs();
+
+            const allEmpty = Object.values(groupedFAQs).every(
+                (group) => Array.isArray(group) && group.length === 0
+            );
+
 
             if (allEmpty) {
                 res.status(404).json({
@@ -130,7 +150,7 @@ export default {
         }
     },
 
-    deleteFAQs: async (req: Request, res: Response) => { 
+    deleteFAQs: async (req: Request, res: Response) => {
         const { faqs } = req.body;
 
         if (!faqs || !Array.isArray(faqs) || faqs.length === 0) {

--- a/src/services/faq.service.ts
+++ b/src/services/faq.service.ts
@@ -76,6 +76,19 @@ export default {
 
             return affectedRows;
         });
+    },
+    getFAQsByCategory: async (faq_category: string) => {
+        const result = await db.raw(
+            `SELECT * FROM faq
+            WHERE faq_category = ?`,
+        [faq_category])
+
+        const faqs = result.rows;
+
+        if (faqs.length == 0)
+            return [];
+
+        return faqs;
     }
 
 


### PR DESCRIPTION
# [Feat]: Add filter by category to FAQs API

## Description
### Briefly describe the purpose of this pull request.
- Implemented filtering for FAQs by category.
- Allows client to query FAQs API with a specific `faq_category` parameter.

### Mention any relevant context or background.
- Previously, FAQs API returned all FAQs without category filtering.
- This feature improves usability by letting users fetch FAQs relevant to their needs.

## Changes
### Outline the main changes made in this pull request.
- Updated FAQs service to support filtering by category using raw SQL.
- Modified controller to handle `faq_category` query parameter.
- Added validation for `faq_category` values.

## Testing
- [x] Local
<img width="851" height="955" alt="image" src="https://github.com/user-attachments/assets/79a6f414-e86c-44f5-8a32-252a511b8c60" />
<img width="810" height="949" alt="image" src="https://github.com/user-attachments/assets/a6ef8519-d7b7-45c2-8828-d668e1e57b55" />
<img width="801" height="624" alt="image" src="https://github.com/user-attachments/assets/fe60b1be-0e7c-4fc5-a6b7-79be5463fa90" />
<img width="795" height="625" alt="image" src="https://github.com/user-attachments/assets/4e5b0d2b-2fe2-4e92-a0ac-99a07333034a" />
