### PR TITLE
Feature/add filter for activity, et news get all api

### DIFF
--- a/src/services/activity.service.ts
+++ b/src/services/activity.service.ts
@@ -4,30 +4,60 @@ import { Activity } from "../types/activity";
 export default {
     getActivityById: async (id: string): Promise<Activity | null> => {
         try {
-            const activity = await db("activity")
-                .select("*")
-                .where("activity_id", id);
-
-            return activity.length > 0 ? activity[0] : null;
+            const result = await db.raw(
+                `
+                SELECT *
+                FROM activity
+                WHERE activity_id = ?
+                `,
+                [id]
+            );
+            return result.rows.length > 0 ? result.rows[0] : null;
         } catch (error) {
             console.log(error);
             throw new Error('Error getting activities: ' + error.message);
         }
     },
-    getAllActivities: async (): Promise<{ ongoing: Activity[]; completed: Record<string, Activity[]> }> => {
+    getAllActivities: async (categories?: string[]): Promise<{ ongoing: Activity[]; completed: Record<string, Activity[]> }> => {
         try {
             const now = new Date();
-
-            const ongoing = await db("activity")
-                .select("*")
-                .where("start_date", "<=", now)
-                .where("end_date", ">=", now);
-
-            const completedRaw = await db("activity")
-                .select("*")
-                .where("end_date", "<", now);
-
-            const completed: Record<string, Activity[]> = completedRaw.reduce((acc, activity) => {
+            let ongoingResult, completedResult;
+            if (Array.isArray(categories) && categories.length > 0) {
+                ongoingResult = await db.raw(
+                    `
+                    SELECT *
+                    FROM activity
+                    WHERE start_date <= ? AND end_date >= ? AND activity_category = ANY(?)
+                    `,
+                    [now, now, categories]
+                );
+                completedResult = await db.raw(
+                    `
+                    SELECT *
+                    FROM activity
+                    WHERE end_date < ? AND activity_category = ANY(?)
+                    `,
+                    [now, categories]
+                );
+            } else {
+                ongoingResult = await db.raw(
+                    `
+                    SELECT *
+                    FROM activity
+                    WHERE start_date <= ? AND end_date >= ?
+                    `,
+                    [now, now]
+                );
+                completedResult = await db.raw(
+                    `
+                    SELECT *
+                    FROM activity
+                    WHERE end_date < ?
+                    `,
+                    [now]
+                );
+            }
+            const completed: Record<string, Activity[]> = completedResult.rows.reduce((acc, activity) => {
                 const category = activity.activity_category;
                 if (!acc[category]) {
                     acc[category] = [];
@@ -35,8 +65,7 @@ export default {
                 acc[category].push(activity);
                 return acc;
             }, {} as Record<string, Activity[]>);
-
-            return { ongoing, completed };
+            return { ongoing: ongoingResult.rows, completed };
         } catch (error) {
             console.log(error);
             throw new Error('Error getting activities: ' + error.message);
@@ -44,42 +73,111 @@ export default {
     },
 
     deleteActivityById: async (id: string) => {
-        return db("activity")
-            .where("activity_id", id)
-            .del();
+        const result = await db.raw(
+            `
+            DELETE FROM activity
+            WHERE activity_id = ?
+            `,
+            [id]
+        );
+        return result.rowCount;
     },
 
     deleteActivities: async (activities: string[]) => {
         if (!activities || !Array.isArray(activities) || activities.length === 0) {
             throw new Error("Invalid Data");
         }
-                
         return db.transaction(async (trx) => {
-            let affectedRows = 0;
-            for (const activityId of activities) {
-                const deletedActivities = await trx("activity")
-                    .where('activity_id', activityId)
-                    .del();
-                affectedRows += deletedActivities;
-            }
-
-            return affectedRows;
+            const result = await trx.raw(
+                `
+                DELETE FROM activity
+                WHERE activity_id = ANY(?)
+                `,
+                [activities]
+            );
+            return result.rowCount;
         });
     },
-    
-    updateActivity: async (id: string, activity: Activity) => {
-        const updatedActivity = await db("activity")
-            .where("activity_id", id)
-            .update(activity)
-            .returning("*");
 
-        if (updatedActivity.length === 0) return null;
-        return updatedActivity;
+    updateActivity: async (id: string, activity: Activity) => {
+        const {
+            title,
+            activity_category,
+            meta_description,
+            thumbnail_image_url,
+            start_date,
+            end_date,
+            register_number,
+            participated_number,
+            expense_money,
+            visible,
+            content
+        } = activity;
+        const result = await db.raw(
+            `
+            UPDATE activity
+            SET title = ?, activity_category = ?, meta_description = ?, thumbnail_image_url = ?,
+                start_date = ?, end_date = ?, register_number = ?, participated_number = ?,
+                expense_money = ?, visible = ?, content = ?
+            WHERE activity_id = ?
+            RETURNING *
+            `,
+            [
+                title,
+                activity_category,
+                meta_description,
+                thumbnail_image_url,
+                start_date,
+                end_date,
+                register_number,
+                participated_number,
+                expense_money,
+                visible,
+                content,
+                id
+            ]
+        );
+        if (!result.rows || result.rows.length === 0) return null;
+        return result.rows;
     },
 
     createActivity: async (activity: Activity) => {
-        return db("activity")
-            .insert(activity)
-            .returning("*");
+        const {
+            title,
+            activity_category,
+            meta_description,
+            thumbnail_image_url,
+            start_date,
+            end_date,
+            register_number,
+            participated_number,
+            expense_money,
+            visible,
+            content,
+        } = activity;
+        const result = await db.raw(
+            `
+            INSERT INTO activity (
+                title, activity_category, meta_description, thumbnail_image_url,
+                start_date, end_date, register_number, participated_number,
+                expense_money, visible, content
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            RETURNING *
+            `,
+            [
+                title,
+                activity_category,
+                meta_description,
+                thumbnail_image_url,
+                start_date,
+                end_date,
+                register_number,
+                participated_number,
+                expense_money,
+                visible,
+                content
+            ]
+        );
+        return result.rows;
     },
 };

--- a/src/services/etNews.service.ts
+++ b/src/services/etNews.service.ts
@@ -2,28 +2,27 @@ import db from '../utils/db.util';
 import { ETNews } from '../types/etNews';
 
 export default {
-    deleteETNews: async ( id: string ) => {
-        return db('et_news')
-            .where('etnews_id', id)
-            .del()
+    deleteETNews: async (id: string) => {
+        const result = await db.raw(
+            `DELETE FROM et_news WHERE etnews_id = ? RETURNING etnews_id`,
+            [id]
+        );
+        return result.rows.length;
     },
 
     deleteMultipleEtNews: async (etNews: string[]) => {
         if (!etNews || !Array.isArray(etNews) || etNews.length === 0) {
             throw new Error("Invalid Data");
         }
-                
-        return db.transaction(async (trx) => {
-            let affectedRows = 0;
-            for (const etNewsId of etNews) {
-                const deletedEtNews = await trx("et_news")
-                    .where('etnews_id', etNewsId)
-                    .del();
-                affectedRows += deletedEtNews;
-            }
 
-            return affectedRows;
-        });
+        const result = await db.raw(
+            `DELETE FROM et_news
+             WHERE etnews_id = ANY(:etNews::uuid[])
+             RETURNING etnews_id`,
+            { etNews }
+        );
+
+        return result.rows.length;
     },
 
     updateETNews: async (id: string, news: ETNews) => {
@@ -36,32 +35,56 @@ export default {
         return updatedNews;
     },
 
-    createNews: async(news: ETNews) => {
-        return db('et_news')
-        .insert(news)
-        .returning('*');
+    createNews: async (news: ETNews) => {
+        const result = await db.raw(
+            `INSERT INTO et_news (title, etnews_category, meta_description, thumbnail_image_url, source, visible, content, view_count)
+            VALUES (:title, :etnews_category, :meta_description, :thumbnail_image_url, :source, :visible, :content, :view_count)
+            RETURNING *`,
+            {
+                title: news.title,
+                etnews_category: news.etnews_category,
+                meta_description: news.meta_description,
+                thumbnail_image_url: news.thumbnail_image_url,
+                source: news.source,
+                visible: news.visible,
+                content: news.content,
+                view_count: news.view_count || 0
+            }
+        );
+        return result.rows[0];
     },
 
-    getETNewsbyID: async(id: string) => {
-        const news = await db("et_news").select("*")
-            .where('etnews_id', id)
-
+    getETNewsbyID: async (id: string) => {
+        const result = await db.raw(
+            `SELECT * FROM et_news WHERE etnews_id = ?`,
+            [id]
+        );
+        const news = result.rows;
         if (news.length === 0) return null;
         return news[0];
     },
 
-    getAllNews: async () => {
+    getAllNews: async (category?: string) => {
         try {
-            // Get all news
-            const news = await db("et_news").select("*");
+            let result;
+            if (category) {
+                result = await db.raw(`SELECT * FROM et_news WHERE etnews_category = ?`, [category]);
+            } else {
+                result = await db.raw(`SELECT * FROM et_news`);
+            }
+            const news = result.rows;
+
+            if (!news || news.length === 0) {
+                return null;
+            }
 
             // Group news by category
             const groupedNews = news.reduce((acc, item) => {
-                const category = item.etnews_category || "Uncategorized";
-                if (!acc[category]) {
-                    acc[category] = [];
+                const cat = item.etnews_category || "Uncategorized";
+                if (!acc[cat]) {
+                    acc[cat] = [];
                 }
-                acc[category].push(item);
+                acc[cat].push(item);
                 return acc;
             }, {} as Record<string, ETNews[]>);
 
@@ -77,4 +100,3 @@ export default {
         }
     }
 }
-

--- a/src/services/etNews.service.ts
+++ b/src/services/etNews.service.ts
@@ -64,11 +64,11 @@ export default {
         return news[0];
     },
 
-    getAllNews: async (category?: string) => {
+    getAllNews: async (categories?: string[]) => {
         try {
             let result;
-            if (category) {
-                result = await db.raw(`SELECT * FROM et_news WHERE etnews_category = ?`, [category]);
+            if (Array.isArray(categories) && categories.length > 0) {
+                result = await db.raw(`SELECT * FROM et_news WHERE etnews_category = ANY(?)`, [categories]);
             } else {
                 result = await db.raw(`SELECT * FROM et_news`);
             }


### PR DESCRIPTION
# [Feature]: Add Category Filter for Activity and etNews

## Description
### Briefly describe the purpose of this pull request.
- Implement category-based filtering for **Activity** and **etNews** modules.
- Allow users to easily browse and retrieve content based on selected categories.

### Mention any relevant context or background.
- Previously, both Activity and etNews APIs returned all data without category distinction.
- Adding a filter improves usability, user experience, and performance by reducing unnecessary payloads.

### Jira Task: [US-225](https://techetclub.atlassian.net/browse/US-225?actionerId=712020%3A5fada779-ca9c-4682-926a-e02d207784e6&sourceType=assign); [US-226](https://techetclub.atlassian.net/browse/US-226?actionerId=712020%3A5fada779-ca9c-4682-926a-e02d207784e6&sourceType=assign)
## Changes
### Outline the main changes made in this pull request.
- Added `category` filter parameter to Activity API.
- Added `category` filter parameter to etNews API.
- Updated service and repository logic to support filtering by category.

### Include screenshots if there are any UI changes.
- N/A – API changes only.

## Testing

- [x] Local – tested endpoints with and without `category` filter.

