### PR TITLE
feat(US236): build api to approve applications

### DIFF
--- a/src/controllers/application.controller.ts
+++ b/src/controllers/application.controller.ts
@@ -1,0 +1,37 @@
+import { Request, Response } from "express";
+
+import applicationService from "../services/application.service";
+
+export default {
+    approveApplication: async (req: Request, res: Response) => {
+        const reviewed_by = req.user?.personnel_id;
+        const { ids } = req.body;
+        const updatedApplications = await applicationService.approveApplication(reviewed_by, ids);
+        try {
+            if (updatedApplications.length === 0 || !updatedApplications) {
+                res.status(404).json({
+                    message: "No applications were updated"
+                });
+                return;
+            }
+
+            res.status(200).json({
+                message: "Applications approved successfully",
+                data: updatedApplications
+            });
+            return;
+        } catch (error) {
+            if (error.message === 'Some applications not found') {
+                res.status(404).json({
+                    message: error.message
+                });
+                return;
+            }
+            res.status(500).json({
+                message: "Internal server error",
+                error: (error as Error).message
+            });
+            return;
+        }
+    }
+}

--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -41,6 +41,7 @@ export default {
                 username: user.username,
                 sysrole_id: user.sysrole_id,
                 sysrole_name: user.sysrole_name,
+                department_name: user.department_name,
             };
 
             const accessToken = jwt.sign(payload, SECRET_KEY, { expiresIn: '2m' });
@@ -100,7 +101,8 @@ export default {
                     personnel_id: decoded.personnel_id,
                     username: decoded.username,
                     sysrole_id: decoded.sysrole_id,
-                    sysrole_name: decoded.sysrole_name
+                    sysrole_name: decoded.sysrole_name,
+                    department_name: decoded.department_name,
                 },
                 SECRET_KEY,
                 { expiresIn: '2m' }
@@ -113,6 +115,7 @@ export default {
                     username: decoded.username,
                     sysrole_id: decoded.sysrole_id,
                     sysrole_name: decoded.sysrole_name,
+                    department_name: decoded.department_name,
                     token_type: 'refresh'
                 },
                 SECRET_KEY,

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import bannerRoute from './routes/banner.route';
 import accountRoute from './routes/account.route'
 import termRoute from './routes/term.route'
 import searchRoute from './routes/search.route'
+import applicationRoute from './routes/application.route';
 import authRoute from './routes/auth.route';
 import YAML from 'yaml';
 import fs from 'fs';
@@ -43,6 +44,7 @@ app.use('/banners', bannerRoute);
 app.use('/accounts', accountRoute);
 app.use('/auth', authRoute)
 app.use('/terms', termRoute)
+app.use('/applications', applicationRoute);
 app.use('/search', searchRoute)
 app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
 

--- a/src/middlewares/authGuard.mdw.ts
+++ b/src/middlewares/authGuard.mdw.ts
@@ -85,6 +85,34 @@ const authGuard = {
             }
         };
     },
+    verifyDepartmentForManageApplication: () => {
+        return async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+            try {
+                if (isAdministrator(req)) {
+                    return next();
+                }
+                const userId = req.user?.personnel_id;
+                const applicationId = req.body['ids']
+
+                if (!userId || !applicationId || applicationId.length === 0) {
+                    res.status(400).json("Missing user IDs for department verification!");
+                    return;
+                }
+
+                const isSameDepartment = await departmentService.checkDepartmentMatchWithApplication(userId, applicationId);
+
+                if (!isSameDepartment) {
+                    res.status(403).json("You do not have permission to access this resource!");
+                    return;
+                }
+
+                next();
+            } catch (error) {
+                console.error('Error checking department match:', error);
+                res.status(500).json("Internal server error!");
+            }
+        };
+    },
     verifyDepartmentForBulk: () => {
         return async (req: Request, res: Response, next: NextFunction): Promise<void> => {
             try {

--- a/src/routes/application.route.ts
+++ b/src/routes/application.route.ts
@@ -1,0 +1,11 @@
+import express from 'express';
+
+import applicationController from '../controllers/application.controller';
+import authGuard from '../middlewares/authGuard.mdw';
+import { managePersonnelRole } from '../global/roles';
+
+const router = express.Router();
+
+router.put('/approve', authGuard.verifyRoles(managePersonnelRole), authGuard.verifyDepartmentForManageApplication(), applicationController.approveApplication);
+
+export default router;

--- a/src/services/application.service.ts
+++ b/src/services/application.service.ts
@@ -1,0 +1,54 @@
+import db from '../utils/db.util';
+
+export default {
+    approveApplication: async (reviewed_by: string, ids: string[]) => {
+        const result = await db.raw(
+            `SELECT * FROM application
+            WHERE application_id = ANY(?::uuid[])`, [ids]
+        );
+        const applications = result.rows;
+        if (applications.length !== ids.length) {
+            throw new Error('Some applications not found');
+        }
+
+        for (const application of applications) {
+            if (application.round < 3) {
+                await db.raw(
+                    `UPDATE application
+                SET round = round + 1, reviewed_by = ?, reviewed_on = NOW()
+                WHERE application_id = ?`, [reviewed_by, application.application_id]
+                );
+            }
+            if (application.round === 3) {
+                await db.raw(
+                    `UPDATE application 
+                SET application_status = 'Approved', reviewed_by = ?, reviewed_on = NOW()
+                WHERE application_id = ?`, [reviewed_by, application.application_id]
+                );
+
+                await db.raw(
+                    `INSERT INTO personnel (personnel_name, phone_number, email, dob, gender, student_id, university, faculty, major, class, cv_type, cv_link)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, [
+                    application.full_name,
+                    application.phone_number,
+                    application.email,
+                    application.dob,
+                    application.gender,
+                    application.student_id,
+                    application.university,
+                    application.faculty,
+                    application.major,
+                    application.class,
+                    application.cv_type,
+                    application.cv_link
+                ]
+                );
+            }
+        }
+        const updatedResult = await db.raw(`
+            SELECT * FROM application
+            WHERE application_id = ANY(?:: uuid[])`, [ids]
+        );
+        return updatedResult.rows;
+    },
+}

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -5,7 +5,8 @@ export default {
     login: async (loginInfo: LoginInfo) => {
         const user = await db('account')
             .join('system_role', 'account.sysrole_id', 'system_role.sysrole_id')
-            .select('account.account_id', 'account.personnel_id', 'account.username', 'account.password', 'account.sysrole_id', 'system_role.sysrole_name')
+            .join('personnel_status', 'account.personnel_id', 'personnel_status.personnel_id')
+            .select('account.account_id', 'account.personnel_id', 'account.username', 'account.password', 'account.sysrole_id', 'system_role.sysrole_name', 'personnel_status.department_name')
             .where('username', loginInfo.username)
             .first()
 

--- a/src/services/department.service.ts
+++ b/src/services/department.service.ts
@@ -28,7 +28,30 @@ const departmentService = {
         }
     },
 
+    checkDepartmentMatchWithApplication: async (userId: string, applicationId: string[]): Promise<boolean> => {
+        try {
+            const [user, application] = await Promise.all([
+                db('personnel')
+                    .join('personnel_status', 'personnel.personnel_id', '=', 'personnel_status.personnel_id')
+                    .select('personnel_status.department_name')
+                    .where('personnel.personnel_id', userId)
+                    .first(),
+                db('application')
+                    .select('department_name')
+                    .whereIn('application_id', applicationId)
+                    .first()
+            ]);
 
+            if (user && application && user.department_name === application.department_name) {
+                console.log(`User ${user} and Application ${application} are in the same department: ${user.department_name}`);
+                return true;
+            }
+            return false;
+        } catch (error) {
+            console.error('Error checking department match:', error);
+            throw new Error('Error checking department match: ' + error.message);
+        }
+    },
     checkUserDepartment: async (userId: string, targetDepartment: string): Promise<boolean> => {
         try {
             const user = await db('personnel')


### PR DESCRIPTION
# [Feat][US236]: Build API to approve applications

## Description
### Briefly describe the purpose of this pull request.
- Implemented API endpoint to approve applications.
- Supports approval logic based on application round and updates related records.

### Mention any relevant context or background.
- If the application `round < 3`, only the status is updated.
- If the application `round = 3`, the status is updated and a new record is created in the `personnel` table.

### Jira Task: 
- [US236](https://techetclub.atlassian.net/browse/US-236)

## Changes
### Outline the main changes made in this pull request.
- Added new endpoint: `PUT /applications/{id}/approve`.
- Implemented logic:
  - Update status for applications with `round < 3`.
  - Update status and insert into `personnel` table for applications with `round = 3`.
- Reused existing API for creating personnel.

## Testing
- [x] Local
<img width="1486" height="937" alt="image" src="https://github.com/user-attachments/assets/c3ca7f51-747d-4fa1-882d-ea784be7e1f6" />
<img width="1267" height="945" alt="image" src="https://github.com/user-attachments/assets/13127876-4ce7-47ab-9744-acb85a416be3" />
<img width="1009" height="367" alt="image" src="https://github.com/user-attachments/assets/864789e1-c00b-42b6-8f39-3b2e824f75bc" />


