### PR TITLE
feat(US237): build api to reject application

### DIFF
--- a/src/controllers/application.controller.ts
+++ b/src/controllers/application.controller.ts
@@ -33,5 +33,40 @@ export default {
             });
             return;
         }
+    },
+    rejectApplication: async (req: Request, res: Response) => {
+        const reviewed_by = req.user?.personnel_id;
+        const { ids } = req.body;
+        try {
+            const updatedApplications = await applicationService.rejectApplication(reviewed_by, ids);
+            res.status(200).json({
+                message: "Applications rejected successfully",
+                data: updatedApplications
+            });
+            return;
+        } catch (error) {
+            if (error.message === 'No applications to reject') {
+                res.status(404).json({
+                    message: error.message
+                });
+                return;
+            }
+            if (error.message === 'Some applications not found') {
+                res.status(404).json({
+                    message: error.message
+                });
+                return;
+            }
+            if (error.message === 'Cannot reject an already approved application') {
+                res.status(409).json({
+                    message: error.message
+                });
+                return;
+            }
+            res.status(500).json({
+                message: "Internal server error" + error.message,
+            });
+            return;
+        }
     }
 }

--- a/src/routes/application.route.ts
+++ b/src/routes/application.route.ts
@@ -7,5 +7,6 @@ import { managePersonnelRole } from '../global/roles';
 const router = express.Router();
 
 router.put('/approve', authGuard.verifyRoles(managePersonnelRole), authGuard.verifyDepartmentForManageApplication(), applicationController.approveApplication);
+router.put('/reject', authGuard.verifyRoles(managePersonnelRole), authGuard.verifyDepartmentForManageApplication(), applicationController.rejectApplication);
 
 export default router;

--- a/src/services/application.service.ts
+++ b/src/services/application.service.ts
@@ -51,4 +51,33 @@ export default {
         );
         return updatedResult.rows;
     },
+
+    rejectApplication: async (reviewed_by: string, ids: string[]) => {
+        const result = await db.raw(
+            `SELECT * FROM application
+            WHERE application_id = ANY(?::uuid[])`, [ids]
+        );
+        const applications = result.rows;
+        if (applications.length === 0) {
+            throw new Error('No applications to reject');
+        }
+        if (applications.length !== ids.length) {
+            throw new Error('Some applications not found');
+        }
+        for (const application of applications) {
+            if (application.round === 3 && application.application_status === 'Approved') {
+                throw new Error('Cannot reject an already approved application');
+            }
+        }
+        await db.raw(
+            `UPDATE application
+            SET application_status = 'Rejected', reviewed_by = ?, reviewed_on = NOW()
+            WHERE application_id = ANY(?::uuid[])`, [reviewed_by, ids]
+        );
+        const updatedResult = await db.raw(`
+            SELECT * FROM application
+            WHERE application_id = ANY(?:: uuid[])`, [ids]
+        );
+        return updatedResult.rows;
+    }
 }


### PR DESCRIPTION
# [Feat][US237]: Build API to reject application

## Description
### Briefly describe the purpose of this pull request.
- Implemented API endpoint to reject applications.
- Supports rejection workflow by updating application status and storing rejection metadata.

### Mention any relevant context or background.
- Applications that do not meet requirements should be marked as `Rejected`.
- This feature aligns with the approval/restore flow, providing complete lifecycle management.

### Jira Task:
- [US237](https://techetclub.atlassian.net/browse/US-237)

## Changes
### Outline the main changes made in this pull request.
- Added new endpoint: `PUT /applications/reject`.
- Implemented logic to update `application_status` to `Rejected`.
- Captured `reviewed_by` and `reviewed_on` fields for audit purposes.

## Testing
- [x] Local
<img width="1498" height="855" alt="image" src="https://github.com/user-attachments/assets/f2c35a1e-b483-4197-824e-fddc4a0c8899" />
<img width="1490" height="473" alt="image" src="https://github.com/user-attachments/assets/f3ecf6c9-d709-4be8-bc4f-bc1f44d1eabf" />
<img width="1488" height="435" alt="image" src="https://github.com/user-attachments/assets/ff0ec79d-4a9a-4914-a454-df3fe6cab3ff" />

