### PR TITLE
feature: build api to export applications

### DIFF
--- a/src/routes/application.route.ts
+++ b/src/routes/application.route.ts
@@ -7,6 +7,7 @@ import { managePersonnelRole } from '../global/roles';
 const router = express.Router();
 
 router.get('/', authGuard.verifyRoles(managePersonnelRole), applicationController.getApplications);
+router.get('/export', applicationController.exportApplications);
 router.get('/:id', authGuard.verifyRoles(managePersonnelRole), authGuard.verifyDepartmentForManageApplication(), applicationController.getApplicationById);
 router.put('/restore', authGuard.verifyRoles(managePersonnelRole), authGuard.verifyDepartmentForManageApplication(), applicationController.restoreApplication);
 router.put('/approve', authGuard.verifyRoles(managePersonnelRole), authGuard.verifyDepartmentForManageApplication(), applicationController.approveApplication);

--- a/src/services/application.service.ts
+++ b/src/services/application.service.ts
@@ -1,4 +1,6 @@
+import { application } from 'express';
 import db from '../utils/db.util';
+
 
 export default {
     approveApplication: async (reviewed_by: string, ids: string[]) => {
@@ -146,5 +148,5 @@ export default {
             [ids]
         )
         return restoredApplications.rows
-    },
+    }
 }


### PR DESCRIPTION
# [US233]: Build API to Export Applications with Optional Filters

## Description
### Briefly describe the purpose of this pull request.
- Implemented a backend API to export application data.
- Supports optional filters by:
  - Round
  - Status  

### Mention any relevant context or background.
- Exported data is returned in a structured file format (e.g., CSV/Excel).
- Useful for reporting, analysis, and administrative tasks.

### Jira Task: US-233

## Changes
### Outline the main changes made in this pull request.
- Added new endpoint: `GET /applications/export`
- Query parameters supported:
  - `round` – filter applications by round.
  - `status` – filter applications by status.
- Implemented export logic to generate downloadable file (CSV/Excel).
- Integrated input validation and error handling.

## Testing

- [x] Local with Postman
<img width="1915" height="1016" alt="Screenshot 2025-09-09 221700" src="https://github.com/user-attachments/assets/44fe3c58-9fb7-4cdf-995c-4f998f873bf9" />

