### PR TITLE
fix: remove duplicate cohort name in application table

### DIFF
--- a/src/database/migrations/create_tables.sql
+++ b/src/database/migrations/create_tables.sql
@@ -244,8 +244,7 @@ CREATE TABLE IF NOT EXISTS application (
     note TEXT,
     cohort_name VARCHAR(10) NOT NULL DEFAULT 'K49',
     reviewed_by UUID REFERENCES personnel(personnel_id) DEFAULT NULL,
-    reviewed_on TIMESTAMP DEFAULT NULL,
-    cohort_name VARCHAR(10) NOT NULL DEFAULT 'K49'
+    reviewed_on TIMESTAMP DEFAULT NULL
 );
 
 CREATE TABLE IF NOT EXISTS recruitment (


### PR DESCRIPTION
# [Fix]: Remove duplicate cohort_name in Application table

## Description
### Briefly describe the purpose of this pull request.
- Removed duplicate `cohort_name` column definition in the `Application` table schema.
- Ensured table structure is consistent with intended design.

### Mention any relevant context or background.
- The `Application` table previously had `cohort_name` defined more than once, which could cause conflicts during migrations or queries.

## Changes
### Outline the main changes made in this pull request.
- Updated DB script to remove the duplicated `cohort_name` column.
- Verified constraints and relationships remain unaffected.
- Adjusted entity definition accordingly.

## Testing
- [x] Local