### PR TITLE
feature: build api to get status of the first recruitment table row

### DIFF
--- a/src/controllers/recruitment.controller.ts
+++ b/src/controllers/recruitment.controller.ts
@@ -1,0 +1,28 @@
+import { Request, Response } from 'express';
+import recruitmentService from '../services/recruitment.service';
+
+export default {
+    getStatusofFirstRecruitment: async (req: Request, res: Response): Promise<void> => {
+        try {
+            const status = await recruitmentService.getStatusofFirstRecruitment();
+            if (status === null) {
+                res.status(404).json({
+                    message: "No recruitment found",
+                    data: null
+                });
+                return;
+            }
+            res.status(200).json({
+                message: "Retrieved status of first recruitment successfully",
+                data: status
+            });
+            return;
+        } catch (error) {
+            res.status(500).json({
+                message: "Internal server error",
+                error: (error as Error).message
+            });
+            return
+        }
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import accountRoute from './routes/account.route'
 import termRoute from './routes/term.route'
 import searchRoute from './routes/search.route'
 import applicationRoute from './routes/application.route';
+import recruitmentRoute from './routes/recruitment.route';
 import authRoute from './routes/auth.route';
 import YAML from 'yaml';
 import fs from 'fs';
@@ -46,7 +47,8 @@ app.use('/auth', authRoute)
 app.use('/terms', termRoute)
 app.use('/applications', applicationRoute);
 app.use('/search', searchRoute)
-app.use('/applications', applicationRoute)
+app.use('/applications', applicationRoute);
+app.use('/recruitment', recruitmentRoute);
 app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
 
 const PORT = process.env.PORT || 8080;

--- a/src/routes/recruitment.route.ts
+++ b/src/routes/recruitment.route.ts
@@ -1,0 +1,10 @@
+import express, { Request, Response } from 'express';
+import authGuard from '../middlewares/authGuard.mdw';
+
+import recruitmentController from '../controllers/recruitment.controller';
+
+const router = express.Router();
+
+router.get('/', recruitmentController.getStatusofFirstRecruitment);
+
+export default router;

--- a/src/services/recruitment.service.ts
+++ b/src/services/recruitment.service.ts
@@ -3,9 +3,9 @@ import db from '../utils/db.util';
 export default {
     getStatusofFirstRecruitment: async () => {
         const result = await db.raw(
-            `SELECT recruitment_status FROM recruitment
-            ORDER BY start_date ASC LIMIT 1`
+            `SELECT is_open FROM recruitment
+            ORDER BY created_at ASC LIMIT 1`
         );
-        return result.rows[0]?.recruitment_status || null;
+        return result.rows[0]?.is_open || null;
     }
 }

--- a/src/services/recruitment.service.ts
+++ b/src/services/recruitment.service.ts
@@ -1,0 +1,11 @@
+import db from '../utils/db.util';
+
+export default {
+    getStatusofFirstRecruitment: async () => {
+        const result = await db.raw(
+            `SELECT recruitment_status FROM recruitment
+            ORDER BY start_date ASC LIMIT 1`
+        );
+        return result.rows[0]?.recruitment_status || null;
+    }
+}


### PR DESCRIPTION
# [US244]: Build API to Get Status of the First Recruitment Table Row

## Description
### Briefly describe the purpose of this pull request.
- Implemented a backend API to retrieve the status of the **first row** in the recruitment table.
- Helps quickly identify the most recent recruitment entry status for use in dashboards or workflow checks.

### Mention any relevant context or background.
- Designed to support frontend components that need a quick status check without fetching the entire table.
- Returns a minimal and optimized payload.

### Jira Task: US-244 

## Changes
### Outline the main changes made in this pull request.
- Added new endpoint: `GET /recruitment`
- Logic to fetch and return only the **status** field of the first row.
- Added input validation and error handling for empty datasets.



## Testing

- [x] Local – tested retrieval with sample recruitment data.

